### PR TITLE
 Fix usage of octopus-ts under isolatedModules flag

### DIFF
--- a/packages/octopus-ts/index.ts
+++ b/packages/octopus-ts/index.ts
@@ -1,1 +1,1 @@
-export { components as Octopus } from './dist/octopus'
+export type { components as Octopus } from './dist/octopus'


### PR DESCRIPTION
Similar to earlier PR to make the same change in manifest-ts. I thought I already made PR for this, but guess not.